### PR TITLE
chore(captures): remove not null constraint from captures.user_id

### DIFF
--- a/db/migrations/20170226154002_remove_not_null_on_captures_user_id.js
+++ b/db/migrations/20170226154002_remove_not_null_on_captures_user_id.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.raw('ALTER TABLE captures ALTER COLUMN user_id DROP NOT NULL');
+};
+
+exports.down = function (knex, Promise) {
+  return knex.raw('ALTER TABLE captures ALTER COLUMN user_id SET NOT NULL');
+};


### PR DESCRIPTION
remove the not null constraint so that we can then stop writing to the column and then drop the column altogether