### PR TITLE
chore(captures): stop writing to captures.user_id

### DIFF
--- a/src/models/capture.js
+++ b/src/models/capture.js
@@ -12,7 +12,6 @@ module.exports = Bookshelf.model('Capture', Bookshelf.Model.extend({
   serialize () {
     return {
       dex_id: this.get('dex_id'),
-      user_id: this.get('user_id'),
       pokemon: this.related('pokemon').get('capture_summary'),
       captured: this.get('captured')
     };

--- a/src/validators/captures/list.js
+++ b/src/validators/captures/list.js
@@ -3,7 +3,5 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
-  dex: Joi.number().integer(),
-  user: Joi.number().integer()
-})
-.xor(['dex', 'user']);
+  dex: Joi.number().integer().required()
+});

--- a/test/models/capture.test.js
+++ b/test/models/capture.test.js
@@ -19,7 +19,6 @@ describe('capture model', () => {
       expect(json).to.have.all.keys([
         'pokemon',
         'dex_id',
-        'user_id',
         'captured'
       ]);
       expect(json.pokemon).to.have.all.keys([

--- a/test/models/dex.test.js
+++ b/test/models/dex.test.js
@@ -12,8 +12,8 @@ const secondPokemon = Factory.build('pokemon', { id: 2, national_id: 2 });
 
 const dex = Factory.build('dex', { user_id: user.id });
 
-const firstCapture  = Factory.build('capture', { pokemon_id: firstPokemon.id, user_id: user.id, dex_id: dex.id });
-const secondCapture = Factory.build('capture', { pokemon_id: secondPokemon.id, user_id: user.id, dex_id: dex.id });
+const firstCapture  = Factory.build('capture', { pokemon_id: firstPokemon.id, dex_id: dex.id });
+const secondCapture = Factory.build('capture', { pokemon_id: secondPokemon.id, dex_id: dex.id });
 
 describe('dex model', () => {
 

--- a/test/plugins/features/captures/controller.test.js
+++ b/test/plugins/features/captures/controller.test.js
@@ -19,8 +19,8 @@ const dex       = Factory.build('dex', { user_id: user.id, generation: 1 });
 const otherDex  = Factory.build('dex', { user_id: otherUser.id, generation: 1 });
 const regionDex = Factory.build('dex', { title: 'Another', slug: 'another', user_id: user.id, generation: 1, region: 'alola' });
 
-const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, user_id: user.id, dex_id: dex.id });
-const otherCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, user_id: otherUser.id, dex_id: otherDex.id });
+const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, dex_id: dex.id });
+const otherCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, dex_id: otherDex.id });
 
 describe('captures controller', () => {
 
@@ -34,22 +34,6 @@ describe('captures controller', () => {
   });
 
   describe('list', () => {
-
-    it('returns a collection of captures filtered by user_id, filling in those that do not exist', () => {
-      return new Pokemon().query((qb) => qb.orderBy('id')).fetchAll()
-      .get('models')
-      .then((pokemon) => Controller.list({ user: user.id }, pokemon))
-      .map((capture) => capture.serialize())
-      .then((captures) => {
-        expect(captures).to.have.length(2);
-        expect(captures[0].pokemon.id).to.eql(firstPokemon.id);
-        expect(captures[0].user_id).to.eql(user.id);
-        expect(captures[0].captured).to.be.true;
-        expect(captures[1].pokemon.id).to.eql(secondPokemon.id);
-        expect(captures[1].user_id).to.eql(user.id);
-        expect(captures[1].captured).to.be.false;
-      });
-    });
 
     it('returns a collection of captures filtered by dex_id, filling in those that do not exist', () => {
       return new Pokemon().query((qb) => qb.orderBy('id')).fetchAll()
@@ -94,14 +78,6 @@ describe('captures controller', () => {
       });
     });
 
-    it('rejects for a user id that does not exist', () => {
-      return Controller.list({ user: -1 })
-      .catch((err) => err)
-      .then((err) => {
-        expect(err).to.be.an.instanceof(Errors.NotFound);
-      });
-    });
-
     it('rejects for a dex id that does not exist', () => {
       return Controller.list({ dex: -1 })
       .catch((err) => err)
@@ -119,7 +95,6 @@ describe('captures controller', () => {
       .then((captures) => {
         expect(captures).to.have.length(1);
         expect(captures.at(0).get('pokemon_id')).to.eql(secondPokemon.id);
-        expect(captures.at(0).get('user_id')).to.eql(user.id);
         expect(captures.at(0).get('dex_id')).to.eql(dex.id);
         expect(captures.at(0).get('captured')).to.be.true;
       });
@@ -154,7 +129,6 @@ describe('captures controller', () => {
       .then((captures) => {
         expect(captures).to.have.length(1);
         expect(captures.at(0).get('pokemon_id')).to.eql(firstPokemon.id);
-        expect(captures.at(0).get('user_id')).to.eql(user.id);
         expect(captures.at(0).get('captured')).to.be.true;
       });
     });

--- a/test/plugins/features/captures/index.test.js
+++ b/test/plugins/features/captures/index.test.js
@@ -14,7 +14,7 @@ const user = Factory.build('user');
 
 const dex = Factory.build('dex', { user_id: user.id });
 
-const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, user_id: user.id, dex_id: dex.id });
+const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.id, dex_id: dex.id });
 
 const auth = `Bearer ${JWT.sign(user, Config.JWT_SECRET)}`;
 
@@ -34,7 +34,7 @@ describe('captures integration', () => {
     it('returns a collection of captures', () => {
       return Server.inject({
         method: 'GET',
-        url: `/captures?user=${user.id}`
+        url: `/captures?dex=${dex.id}`
       })
       .then((res) => {
         expect(res.statusCode).to.eql(200);

--- a/test/plugins/features/dexes/controller.test.js
+++ b/test/plugins/features/dexes/controller.test.js
@@ -18,9 +18,9 @@ const oldGenPokemon      = Factory.build('pokemon', { id: 1, national_id: 1, gen
 const newGenPokemon      = Factory.build('pokemon', { id: 2, national_id: 2, generation: firstDex.generation, alola_id: 2 });
 const otherRegionPokemon = Factory.build('pokemon', { id: 3, national_id: 3, generation: firstDex.generation - 1, hoenn_id: 1 });
 
-const oldGenCapture      = Factory.build('capture', { pokemon_id: oldGenPokemon.id, dex_id: firstDex.id, user_id: firstUser.id });
-const newGenCapture      = Factory.build('capture', { pokemon_id: newGenPokemon.id, dex_id: firstDex.id, user_id: firstUser.id });
-const otherRegionCapture = Factory.build('capture', { pokemon_id: otherRegionPokemon.id, dex_id: firstDex.id, user_id: firstUser.id });
+const oldGenCapture      = Factory.build('capture', { pokemon_id: oldGenPokemon.id, dex_id: firstDex.id });
+const newGenCapture      = Factory.build('capture', { pokemon_id: newGenPokemon.id, dex_id: firstDex.id });
+const otherRegionCapture = Factory.build('capture', { pokemon_id: otherRegionPokemon.id, dex_id: firstDex.id });
 
 describe('dexes controller', () => {
 

--- a/test/validators/captures/list.test.js
+++ b/test/validators/captures/list.test.js
@@ -6,23 +6,15 @@ const CapturesListValidator = require('../../../src/validators/captures/list');
 
 describe('captures list validator', () => {
 
-  it('requires either dex or user', () => {
-    const data = {};
-    const result = Joi.validate(data, CapturesListValidator);
-
-    expect(result.error.details[0].path).to.eql('value');
-    expect(result.error.details[0].type).to.eql('object.missing');
-  });
-
-  it('disallows both dex and user', () => {
-    const data = { dex: 1, user: 1 };
-    const result = Joi.validate(data, CapturesListValidator);
-
-    expect(result.error.details[0].path).to.eql('value');
-    expect(result.error.details[0].type).to.eql('object.xor');
-  });
-
   describe('dex', () => {
+
+    it('is required', () => {
+      const data = {};
+      const result = Joi.validate(data, CapturesListValidator);
+
+      expect(result.error.details[0].path).to.eql('dex');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
 
     it('allows integers', () => {
       const data = { dex: 1 };
@@ -36,25 +28,6 @@ describe('captures list validator', () => {
       const result = Joi.validate(data, CapturesListValidator);
 
       expect(result.error.details[0].path).to.eql('dex');
-      expect(result.error.details[0].type).to.eql('number.base');
-    });
-
-  });
-
-  describe('user', () => {
-
-    it('allows integers', () => {
-      const data = { user: 1 };
-      const result = Joi.validate(data, CapturesListValidator);
-
-      expect(result.error).to.not.exist;
-    });
-
-    it('disallows strings', () => {
-      const data = { user: 'test' };
-      const result = Joi.validate(data, CapturesListValidator);
-
-      expect(result.error.details[0].path).to.eql('user');
       expect(result.error.details[0].type).to.eql('number.base');
     });
 


### PR DESCRIPTION
now that theres no longer a not null constraint on `captures.user_id`, we can stop writing to it so that we can drop the column completely in the next pr without any worries of errors