### PR TITLE
chore(captures): drop captures.user_id

### DIFF
--- a/db/migrations/20170226170804_drop_captures_user_id.js
+++ b/db/migrations/20170226170804_drop_captures_user_id.js
@@ -1,0 +1,13 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.table('captures', (table) => {
+    table.dropColumn('user_id');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('captures', (table) => {
+    table.integer('user_id').references('id').inTable('users').onDelete('CASCADE').index();
+  });
+};


### PR DESCRIPTION
now that we're not doing anything with this column, we should be able to safely drop it