### PR TITLE
feat(pokemon): add us_location/um_location columns on pokemon

### DIFF
--- a/db/migrations/20171226183443_add_usum_locations_to_pokemon.js
+++ b/db/migrations/20171226183443_add_usum_locations_to_pokemon.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex.schema.table('pokemon', (table) => {
+    table.text('us_location');
+    table.text('um_location');
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('pokemon', (table) => {
+    table.dropColumn('us_location');
+    table.dropColumn('um_location');
+  });
+};

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -105,6 +105,12 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
     },
     moon_locations () {
       return this.get('moon_location') ? this.get('moon_location').split(', ') : [];
+    },
+    us_locations () {
+      return this.get('us_location') ? this.get('us_location').split(', ') : [];
+    },
+    um_locations () {
+      return this.get('um_location') ? this.get('um_location').split(', ') : [];
     }
   },
   serialize (request) {
@@ -170,6 +176,8 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
         as_locations: this.get('as_locations'),
         sun_locations: this.get('sun_locations'),
         moon_locations: this.get('moon_locations'),
+        us_locations: this.get('us_locations'),
+        um_locations: this.get('um_locations'),
         evolution_family: family
       });
     });

--- a/test/models/pokemon.test.js
+++ b/test/models/pokemon.test.js
@@ -250,6 +250,30 @@ describe('pokemon model', () => {
 
     });
 
+    describe('us_locations', () => {
+
+      it('splits by commas', () => {
+        expect(Pokemon.forge({ us_location: 'Route 1, Route 2' }).get('us_locations')).to.eql(['Route 1', 'Route 2']);
+      });
+
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ us_location: null }).get('us_locations')).to.eql([]);
+      });
+
+    });
+
+    describe('um_locations', () => {
+
+      it('splits by commas', () => {
+        expect(Pokemon.forge({ um_location: 'Route 1, Route 2' }).get('um_locations')).to.eql(['Route 1', 'Route 2']);
+      });
+
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ um_location: null }).get('um_locations')).to.eql([]);
+      });
+
+    });
+
   });
 
   describe('serialize', () => {
@@ -283,6 +307,8 @@ describe('pokemon model', () => {
           'as_locations',
           'sun_locations',
           'moon_locations',
+          'us_locations',
+          'um_locations',
           'evolution_family'
         ]);
         expect(json.game_family.id).to.eql(redBlue.id);


### PR DESCRIPTION
- add `{us,um}_location` columns to `pokemon` table
- add `{us,um}_locations` to serialization on pokemon model