### PR TITLE
feat(locations): add locations table and return it with pokemon

### DIFF
--- a/db/migrations/20181118145358_create_locations_table.js
+++ b/db/migrations/20181118145358_create_locations_table.js
@@ -1,0 +1,59 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.createTable('locations', (table) => {
+    table.primary(['game_id', 'pokemon_id']);
+    table.text('game_id').references('id').inTable('games').onDelete('CASCADE').index();
+    table.integer('pokemon_id').references('id').inTable('pokemon').onDelete('CASCADE').index();
+    table.text('value').notNullable();
+  })
+  .then(() => Knex('pokemon'))
+  .map((pokemon) => {
+    return Promise.all([
+      pokemon.x_location && Knex('locations').insert({
+        game_id: 'x',
+        pokemon_id: pokemon.id,
+        value: pokemon.x_location
+      }),
+      pokemon.y_location && Knex('locations').insert({
+        game_id: 'y',
+        pokemon_id: pokemon.id,
+        value: pokemon.y_location
+      }),
+      pokemon.or_location && Knex('locations').insert({
+        game_id: 'omega_ruby',
+        pokemon_id: pokemon.id,
+        value: pokemon.or_location
+      }),
+      pokemon.as_location && Knex('locations').insert({
+        game_id: 'alpha_sapphire',
+        pokemon_id: pokemon.id,
+        value: pokemon.as_location
+      }),
+      pokemon.sun_location && Knex('locations').insert({
+        game_id: 'sun',
+        pokemon_id: pokemon.id,
+        value: pokemon.sun_location
+      }),
+      pokemon.moon_location && Knex('locations').insert({
+        game_id: 'moon',
+        pokemon_id: pokemon.id,
+        value: pokemon.moon_location
+      }),
+      pokemon.us_location && Knex('locations').insert({
+        game_id: 'ultra_sun',
+        pokemon_id: pokemon.id,
+        value: pokemon.us_location
+      }),
+      pokemon.um_location && Knex('locations').insert({
+        game_id: 'ultra_moon',
+        pokemon_id: pokemon.id,
+        value: pokemon.um_location
+      })
+    ]);
+  });
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.dropTable('locations');
+};

--- a/src/models/location.js
+++ b/src/models/location.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const Bookshelf = require('../libraries/bookshelf');
+const Game      = require('./game');
+
+module.exports = Bookshelf.model('Location', Bookshelf.Model.extend({
+  tableName: 'locations',
+  game () {
+    return this.belongsTo(Game, 'game_id');
+  },
+  serialize () {
+    return {
+      game: this.related('game').serialize(),
+      value: this.get('value').split(', ')
+    };
+  }
+}, {
+  RELATED: ['game', 'game.game_family']
+}));

--- a/src/plugins/features/captures/index.js
+++ b/src/plugins/features/captures/index.js
@@ -35,7 +35,7 @@ exports.register = (server, options, next) => {
     }
   }]);
 
-  return new Pokemon().query((qb) => qb.orderBy('id')).fetchAll({ withRelated: Pokemon.RELATED })
+  return new Pokemon().query((qb) => qb.orderBy('id')).fetchAll({ withRelated: Pokemon.CAPTURE_SUMMARY_RELATED })
   .get('models')
   .then((p) => {
     pokemon = p;

--- a/test/factories/location.js
+++ b/test/factories/location.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports = Factory.define('location')
+  .attr('value', 'Route 1, Route 2');

--- a/test/helper.js
+++ b/test/helper.js
@@ -9,5 +9,6 @@ beforeEach(() => {
   .then(() => Knex.raw('TRUNCATE evolutions CASCADE'))
   .then(() => Knex.raw('TRUNCATE games CASCADE'))
   .then(() => Knex.raw('TRUNCATE game_families CASCADE'))
-  .then(() => Knex.raw('TRUNCATE pokemon CASCADE'));
+  .then(() => Knex.raw('TRUNCATE pokemon CASCADE'))
+  .then(() => Knex.raw('TRUNCATE locations CASCADE'));
 });

--- a/test/models/location.test.js
+++ b/test/models/location.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Knex     = require('../../src/libraries/knex');
+const Location = require('../../src/models/location');
+
+const gameFamily = Factory.build('game-family');
+
+const game = Factory.build('game', { game_family_id: gameFamily.id });
+
+const pokemon = Factory.build('pokemon', { game_family_id: gameFamily.id });
+
+const location = Factory.build('location', { game_id: game.id, pokemon_id: pokemon.id });
+
+describe('location model', () => {
+
+  beforeEach(() => {
+    return Knex('game_families').insert(gameFamily)
+    .then(() => Knex('games').insert(game))
+    .then(() => Knex('pokemon').insert(pokemon))
+    .then(() => Knex('locations').insert(location));
+  });
+
+  describe('serialize', () => {
+
+    it('returns the correct fields', () => {
+      return new Location().fetch({ withRelated: Location.RELATED })
+      .then((model) => model.serialize({}))
+      .then((json) => {
+        expect(json).to.have.all.keys([
+          'game',
+          'value'
+        ]);
+        expect(json.value).to.eql(['Route 1', 'Route 2']);
+        expect(json.game.game_family.id).to.eql(gameFamily.id);
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
add `locations` table with a migration that loads the values correctly from the individual location columns (e.g. `x_location`, etc). its being serialized alongside the other locations so that the frontend can be updated with zero downtime.