### PR TITLE
feat(game-family): add regional and national support columns

### DIFF
--- a/db/migrations/20181223145613_add_regional_national_columns_to_game_families_table.js
+++ b/db/migrations/20181223145613_add_regional_national_columns_to_game_families_table.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.table('game_families', (table) => {
+    table.boolean('regional_support').notNullable().defaultTo(false);
+    table.boolean('national_support').notNullable().defaultTo(false);
+  });
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.table('game_families', (table) => {
+    table.dropColumn('regional_support');
+    table.dropColumn('national_support');
+  });
+};

--- a/src/models/game-family.js
+++ b/src/models/game-family.js
@@ -10,6 +10,8 @@ module.exports = Bookshelf.model('GameFamily', Bookshelf.Model.extend({
       generation: this.get('generation'),
       regional_total: this.get('regional_total'),
       national_total: this.get('national_total'),
+      regional_support: this.get('regional_support'),
+      national_support: this.get('national_support'),
       order: this.get('order'),
       published: this.get('published')
     };

--- a/test/factories/game-family.js
+++ b/test/factories/game-family.js
@@ -5,5 +5,7 @@ module.exports = Factory.define('game-family')
   .attr('generation', 1)
   .attr('regional_total', 151)
   .attr('national_total', 151)
+  .attr('regional_support', true)
+  .attr('national_support', true)
   .sequence('order')
   .attr('published', false);

--- a/test/models/game-family.test.js
+++ b/test/models/game-family.test.js
@@ -17,6 +17,8 @@ describe('game family model', () => {
         'generation',
         'regional_total',
         'national_total',
+        'regional_support',
+        'national_support',
         'order',
         'published'
       ]);


### PR DESCRIPTION
add `regional_support` and `national_support` columns to `game_families` so that we can easily configure which games support what