### PR TITLE
feat(users): add 3ds_friend_code and switch_friend_code

### DIFF
--- a/db/migrations/20181226131135_add_switch_friend_code_to_users_table.js
+++ b/db/migrations/20181226131135_add_switch_friend_code_to_users_table.js
@@ -1,0 +1,16 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.string('3ds_friend_code', 14);
+    table.string('switch_friend_code', 17);
+  })
+  .then(() => Knex.raw('UPDATE users SET "3ds_friend_code" = friend_code'));
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.dropColumn('3ds_friend_code');
+    table.dropColumn('switch_friend_code');
+  });
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -16,6 +16,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         id: this.get('id'),
         username: this.get('username'),
         friend_code: this.get('friend_code'),
+        '3ds_friend_code': this.get('3ds_friend_code'),
+        switch_friend_code: this.get('switch_friend_code'),
         date_created: this.get('date_created'),
         date_modified: this.get('date_modified')
       };
@@ -28,6 +30,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         id: this.get('id'),
         username: this.get('username'),
         friend_code: this.get('friend_code'),
+        '3ds_friend_code': this.get('3ds_friend_code'),
+        switch_friend_code: this.get('switch_friend_code'),
         dexes,
         donated: Boolean(this.get('stripe_id')),
         date_created: this.get('date_created'),

--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -47,6 +47,8 @@ exports.create = function (payload, request) {
         username: payload.username,
         password: payload.password,
         friend_code: payload.friend_code,
+        '3ds_friend_code': payload['3ds_friend_code'] || payload.friend_code,
+        switch_friend_code: payload.switch_friend_code,
         referrer: payload.referrer,
         last_ip: ip
       }, { transacting })
@@ -72,6 +74,10 @@ exports.create = function (payload, request) {
 exports.update = function (username, payload, auth) {
   return Bluebird.resolve()
   .then(() => {
+    if (payload.friend_code && !payload['3ds_friend_code']) {
+      payload['3ds_friend_code'] = payload.friend_code;
+    }
+
     if (payload.password) {
       return Bcrypt.hash(payload.password, Config.SALT_ROUNDS)
       .then((hash) => payload.password = hash);

--- a/src/validators/users/create.js
+++ b/src/validators/users/create.js
@@ -5,15 +5,27 @@ const Joi = require('joi');
 module.exports = Joi.object().keys({
   username: Joi.string().token().max(20).trim().required(),
   password: Joi.string().min(8).max(72).required(),
-  friend_code: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]),
+  friend_code: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null])
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid 3DS friend code' } }
+      }
+    }),
+  '3ds_friend_code': Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null])
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid 3DS friend code' } }
+      }
+    }),
+  switch_friend_code: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null])
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid Switch friend code' } }
+      }
+    }),
   referrer: Joi.string().empty(['', null]),
   title: Joi.string().max(300).trim().required(),
   shiny: Joi.boolean().required(),
   game: Joi.string().max(50).trim().required(),
   regional: Joi.boolean().required()
-})
-.options({
-  language: {
-    string: { regex: { base: 'must be a 12-digit number' } }
-  }
 });

--- a/src/validators/users/update.js
+++ b/src/validators/users/update.js
@@ -5,9 +5,21 @@ const Joi = require('joi');
 module.exports = Joi.object().keys({
   password: Joi.string().min(8).max(72).empty(['', null]),
   friend_code: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
-})
-.options({
-  language: {
-    string: { regex: { base: 'must be a 12-digit number' } }
-  }
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid 3DS friend code' } }
+      }
+    }),
+  '3ds_friend_code': Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid 3DS friend code' } }
+      }
+    }),
+  switch_friend_code: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
+    .options({
+      language: {
+        string: { regex: { base: 'must be a valid Switch friend code' } }
+      }
+    })
 });

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -18,6 +18,8 @@ describe('user model', () => {
           'id',
           'username',
           'friend_code',
+          '3ds_friend_code',
+          'switch_friend_code',
           'date_created',
           'date_modified'
         ]);
@@ -39,6 +41,8 @@ describe('user model', () => {
           'id',
           'username',
           'friend_code',
+          '3ds_friend_code',
+          'switch_friend_code',
           'dexes',
           'donated',
           'date_created',

--- a/test/validators/users/create.test.js
+++ b/test/validators/users/create.test.js
@@ -113,7 +113,89 @@ describe('users create validator', () => {
 
       expect(result.error.details[0].path).to.eql('friend_code');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"friend_code" must be a 12-digit number/);
+      expect(result.error).to.match(/"friend_code" must be a valid 3DS friend code/);
+    });
+
+  });
+
+  describe('3ds_friend_code', () => {
+
+    it('is optional', () => {
+      const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('converts null to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value['3ds_friend_code']).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value['3ds_friend_code']).to.be.undefined;
+    });
+
+    it('allows codes in the format of 1234-1234-1234', () => {
+      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('disallows codes not in the format of 1234-1234-1234', () => {
+      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('3ds_friend_code');
+      expect(result.error.details[0].type).to.eql('string.regex.base');
+      expect(result.error).to.match(/"3ds_friend_code" must be a valid 3DS friend code/);
+    });
+
+  });
+
+  describe('switch_friend_code', () => {
+
+    it('is optional', () => {
+      const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('converts null to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', switch_friend_code: null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.switch_friend_code).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', switch_friend_code: '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.switch_friend_code).to.be.undefined;
+    });
+
+    it('allows codes in the format of SW-1234-1234-1234', () => {
+      const data = { username: 'testing', password: 'testtest', switch_friend_code: 'SW-1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('disallows codes not in the format of SW-1234-1234-1234', () => {
+      const data = { username: 'testing', password: 'testtest', switch_friend_code: '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('switch_friend_code');
+      expect(result.error.details[0].type).to.eql('string.regex.base');
+      expect(result.error).to.match(/"switch_friend_code" must be a valid Switch friend code/);
     });
 
   });

--- a/test/validators/users/update.test.js
+++ b/test/validators/users/update.test.js
@@ -69,7 +69,89 @@ describe('users update validator', () => {
 
       expect(result.error.details[0].path).to.eql('friend_code');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"friend_code" must be a 12-digit number/);
+      expect(result.error).to.match(/"friend_code" must be a valid 3DS friend code/);
+    });
+
+  });
+
+  describe('3ds_friend_code', () => {
+
+    it('defaults to null', () => {
+      const data = {};
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value['3ds_friend_code']).to.be.null;
+    });
+
+    it('allows null', () => {
+      const data = { '3ds_friend_code': null };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value['3ds_friend_code']).to.be.null;
+    });
+
+    it('converts the empty string to null', () => {
+      const data = { '3ds_friend_code': '' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value['3ds_friend_code']).to.be.null;
+    });
+
+    it('allows codes in the format of 1234-1234-1234', () => {
+      const data = { '3ds_friend_code': '1234-1234-1234' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('disallows codes not in the format of 1234-1234-1234', () => {
+      const data = { '3ds_friend_code': '234-1234-1234' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error.details[0].path).to.eql('3ds_friend_code');
+      expect(result.error.details[0].type).to.eql('string.regex.base');
+      expect(result.error).to.match(/"3ds_friend_code" must be a valid 3DS friend code/);
+    });
+
+  });
+
+  describe('switch_friend_code', () => {
+
+    it('defaults to null', () => {
+      const data = {};
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.switch_friend_code).to.be.null;
+    });
+
+    it('allows null', () => {
+      const data = { switch_friend_code: null };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.switch_friend_code).to.be.null;
+    });
+
+    it('converts the empty string to null', () => {
+      const data = { switch_friend_code: '' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.switch_friend_code).to.be.null;
+    });
+
+    it('allows codes in the format of SW-1234-1234-1234', () => {
+      const data = { switch_friend_code: 'SW-1234-1234-1234' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('disallows codes not in the format of SW-1234-1234-1234', () => {
+      const data = { switch_friend_code: '1234-1234-1234' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error.details[0].path).to.eql('switch_friend_code');
+      expect(result.error.details[0].type).to.eql('string.regex.base');
+      expect(result.error).to.match(/"switch_friend_code" must be a valid Switch friend code/);
     });
 
   });


### PR DESCRIPTION
add `3ds_friend_code` and `switch_friend_code` and copy all `friend_code`s into `3ds_friend_code`. after the release of let go support, we can go back and remove `friend_code`