### PR TITLE
feat(evolutions): add candy as a trigger

### DIFF
--- a/db/migrations/20190101193537_add_candy_as_evolution_trigger.js
+++ b/db/migrations/20190101193537_add_candy_as_evolution_trigger.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const triggers = ['breed', 'level', 'stone', 'trade', 'candy'];
+
+exports.up = function (Knex, Promise) {
+  const array = triggers.map((trigger) => `'${trigger}'::text`).join(', ');
+
+  return Knex.raw('ALTER TABLE evolutions DROP CONSTRAINT evolutions_trigger_check')
+  .then(() => Knex.raw(`ALTER TABLE evolutions ADD CONSTRAINT evolutions_trigger_check CHECK (trigger = ANY (ARRAY[${array}])) NOT VALID`))
+  .then(() => Knex.raw('ALTER TABLE evolutions VALIDATE CONSTRAINT evolutions_trigger_check'))
+  .then(() => {
+    return Knex.schema.table('evolutions', (table) => {
+      table.integer('candy_count');
+    });
+  });
+};
+
+exports.down = function (Knex, Promise) {
+  const array = triggers.filter((trigger) => trigger !== 'candy').map((trigger) => `'${trigger}'::text`).join(', ');
+
+  return Knex.raw('ALTER TABLE evolutions DROP CONSTRAINT evolutions_trigger_check')
+  .then(() => Knex.raw(`ALTER TABLE evolutions ADD CONSTRAINT evolutions_trigger_check CHECK (trigger = ANY (ARRAY[${array}])) NOT VALID`))
+  .then(() => Knex.raw('ALTER TABLE evolutions VALIDATE CONSTRAINT evolutions_trigger_check'))
+  .then(() => {
+    return Knex.schema.table('evolutions', (table) => {
+      table.dropColumn('candy_count');
+    });
+  });
+};
+
+exports.config = { transaction: false };

--- a/src/models/evolution.js
+++ b/src/models/evolution.js
@@ -15,6 +15,7 @@ module.exports = Bookshelf.model('Evolution', Bookshelf.Model.extend({
     return {
       trigger: this.get('trigger'),
       level: this.get('level') || undefined,
+      candy_count: this.get('candy_count') || undefined,
       stone: this.get('stone') || undefined,
       held_item: this.get('held_item') || undefined,
       notes: this.get('notes') || undefined

--- a/test/models/evolution.test.js
+++ b/test/models/evolution.test.js
@@ -16,6 +16,7 @@ describe('evolution model', () => {
       expect(json).to.have.all.keys([
         'trigger',
         'level',
+        'candy_count',
         'stone',
         'held_item',
         'notes'

--- a/test/models/pokemon.test.js
+++ b/test/models/pokemon.test.js
@@ -299,6 +299,7 @@ describe('pokemon model', () => {
         expect(json.evolution_family.evolutions[0][0]).to.have.all.keys([
           'trigger',
           'level',
+          'candy_count',
           'stone',
           'held_item',
           'notes'


### PR DESCRIPTION
since the only way for meltan to evolve is through candy in pokemon go, it needs to be a valid evolution trigger