### PR TITLE
fix(captures): sort by form if game ids are equal

### DIFF
--- a/src/plugins/features/captures/controller.js
+++ b/src/plugins/features/captures/controller.js
@@ -51,6 +51,13 @@ exports.list = function (query, pokemon) {
         const aId = a.related('pokemon').get('dex_number_properties')[`${dex.related('game').related('game_family').get('id')}_id`];
         const bId = b.related('pokemon').get('dex_number_properties')[`${dex.related('game').related('game_family').get('id')}_id`];
 
+        if (aId === bId) {
+          const aForm = a.related('pokemon').get('form');
+          const bForm = b.related('pokemon').get('form');
+
+          return (aForm || '').localeCompare(bForm);
+        }
+
         return aId - bId;
       }
 


### PR DESCRIPTION
prepping for lets go, there are more than one pokemon with the same regional id (e.g. alolan forms share a regional id). so in order to force a deterministic ordering of the pokemon in the box view, we resort to sorting by form if the numbers are the same. this makes it so that the "normal" form (i.e. no form) will be first.