### PR TITLE
fix(friend-code): rename {3ds,switch}_friend_code to friend_code_{3ds,switch}

### DIFF
--- a/db/migrations/20190103112507_rename_new_friend_code_columns.js
+++ b/db/migrations/20190103112507_rename_new_friend_code_columns.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.string('friend_code_3ds', 14);
+    table.string('friend_code_switch', 17);
+    table.dropColumn('3ds_friend_code');
+    table.dropColumn('switch_friend_code');
+  })
+  .then(() => Knex.raw('UPDATE users SET friend_code_3ds = friend_code'));
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.string('3ds_friend_code', 14);
+    table.string('switch_friend_code', 17);
+    table.dropColumn('friend_code_3ds');
+    table.dropColumn('friend_code_switch');
+  })
+  .then(() => Knex.raw('UPDATE users SET "3ds_friend_code" = friend_code'));
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -16,8 +16,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         id: this.get('id'),
         username: this.get('username'),
         friend_code: this.get('friend_code'),
-        '3ds_friend_code': this.get('3ds_friend_code'),
-        switch_friend_code: this.get('switch_friend_code'),
+        friend_code_3ds: this.get('friend_code_3ds'),
+        friend_code_switch: this.get('friend_code_switch'),
         date_created: this.get('date_created'),
         date_modified: this.get('date_modified')
       };
@@ -30,8 +30,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         id: this.get('id'),
         username: this.get('username'),
         friend_code: this.get('friend_code'),
-        '3ds_friend_code': this.get('3ds_friend_code'),
-        switch_friend_code: this.get('switch_friend_code'),
+        friend_code_3ds: this.get('friend_code_3ds'),
+        friend_code_switch: this.get('friend_code_switch'),
         dexes,
         donated: Boolean(this.get('stripe_id')),
         date_created: this.get('date_created'),

--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -47,8 +47,8 @@ exports.create = function (payload, request) {
         username: payload.username,
         password: payload.password,
         friend_code: payload.friend_code,
-        '3ds_friend_code': payload['3ds_friend_code'] || payload.friend_code,
-        switch_friend_code: payload.switch_friend_code,
+        friend_code_3ds: payload.friend_code_3ds || payload.friend_code,
+        friend_code_switch: payload.friend_code_switch,
         referrer: payload.referrer,
         last_ip: ip
       }, { transacting })
@@ -74,8 +74,8 @@ exports.create = function (payload, request) {
 exports.update = function (username, payload, auth) {
   return Bluebird.resolve()
   .then(() => {
-    if (payload.friend_code && !payload['3ds_friend_code']) {
-      payload['3ds_friend_code'] = payload.friend_code;
+    if (payload.friend_code && !payload.friend_code_3ds) {
+      payload.friend_code_3ds = payload.friend_code;
     }
 
     if (payload.password) {

--- a/src/validators/users/create.js
+++ b/src/validators/users/create.js
@@ -11,13 +11,13 @@ module.exports = Joi.object().keys({
         string: { regex: { base: 'must be a valid 3DS friend code' } }
       }
     }),
-  '3ds_friend_code': Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null])
+  friend_code_3ds: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null])
     .options({
       language: {
         string: { regex: { base: 'must be a valid 3DS friend code' } }
       }
     }),
-  switch_friend_code: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null])
+  friend_code_switch: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null])
     .options({
       language: {
         string: { regex: { base: 'must be a valid Switch friend code' } }

--- a/src/validators/users/update.js
+++ b/src/validators/users/update.js
@@ -10,13 +10,13 @@ module.exports = Joi.object().keys({
         string: { regex: { base: 'must be a valid 3DS friend code' } }
       }
     }),
-  '3ds_friend_code': Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
+  friend_code_3ds: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
     .options({
       language: {
         string: { regex: { base: 'must be a valid 3DS friend code' } }
       }
     }),
-  switch_friend_code: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
+  friend_code_switch: Joi.string().regex(/^SW-\d{4}-\d{4}-\d{4}$/).empty(['', null]).default(null)
     .options({
       language: {
         string: { regex: { base: 'must be a valid Switch friend code' } }

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -18,8 +18,8 @@ describe('user model', () => {
           'id',
           'username',
           'friend_code',
-          '3ds_friend_code',
-          'switch_friend_code',
+          'friend_code_3ds',
+          'friend_code_switch',
           'date_created',
           'date_modified'
         ]);
@@ -41,8 +41,8 @@ describe('user model', () => {
           'id',
           'username',
           'friend_code',
-          '3ds_friend_code',
-          'switch_friend_code',
+          'friend_code_3ds',
+          'friend_code_switch',
           'dexes',
           'donated',
           'date_created',

--- a/test/validators/users/create.test.js
+++ b/test/validators/users/create.test.js
@@ -118,7 +118,7 @@ describe('users create validator', () => {
 
   });
 
-  describe('3ds_friend_code', () => {
+  describe('friend_code_3ds', () => {
 
     it('is optional', () => {
       const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
@@ -128,38 +128,38 @@ describe('users create validator', () => {
     });
 
     it('converts null to undefined', () => {
-      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_3ds: null, title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.value['3ds_friend_code']).to.be.undefined;
+      expect(result.value.friend_code_3ds).to.be.undefined;
     });
 
     it('converts the empty string to undefined', () => {
-      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_3ds: '', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.value['3ds_friend_code']).to.be.undefined;
+      expect(result.value.friend_code_3ds).to.be.undefined;
     });
 
     it('allows codes in the format of 1234-1234-1234', () => {
-      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_3ds: '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
       expect(result.error).to.not.exist;
     });
 
     it('disallows codes not in the format of 1234-1234-1234', () => {
-      const data = { username: 'testing', password: 'testtest', '3ds_friend_code': '234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_3ds: '234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.error.details[0].path).to.eql('3ds_friend_code');
+      expect(result.error.details[0].path).to.eql('friend_code_3ds');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"3ds_friend_code" must be a valid 3DS friend code/);
+      expect(result.error).to.match(/"friend_code_3ds" must be a valid 3DS friend code/);
     });
 
   });
 
-  describe('switch_friend_code', () => {
+  describe('friend_code_switch', () => {
 
     it('is optional', () => {
       const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
@@ -169,33 +169,33 @@ describe('users create validator', () => {
     });
 
     it('converts null to undefined', () => {
-      const data = { username: 'testing', password: 'testtest', switch_friend_code: null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_switch: null, title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.value.switch_friend_code).to.be.undefined;
+      expect(result.value.friend_code_switch).to.be.undefined;
     });
 
     it('converts the empty string to undefined', () => {
-      const data = { username: 'testing', password: 'testtest', switch_friend_code: '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_switch: '', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.value.switch_friend_code).to.be.undefined;
+      expect(result.value.friend_code_switch).to.be.undefined;
     });
 
     it('allows codes in the format of SW-1234-1234-1234', () => {
-      const data = { username: 'testing', password: 'testtest', switch_friend_code: 'SW-1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_switch: 'SW-1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
       expect(result.error).to.not.exist;
     });
 
     it('disallows codes not in the format of SW-1234-1234-1234', () => {
-      const data = { username: 'testing', password: 'testtest', switch_friend_code: '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
+      const data = { username: 'testing', password: 'testtest', friend_code_switch: '1234-1234-1234', title: 'Test', shiny: false, game: 'a', regional: true };
       const result = Joi.validate(data, UsersCreateValidator);
 
-      expect(result.error.details[0].path).to.eql('switch_friend_code');
+      expect(result.error.details[0].path).to.eql('friend_code_switch');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"switch_friend_code" must be a valid Switch friend code/);
+      expect(result.error).to.match(/"friend_code_switch" must be a valid Switch friend code/);
     });
 
   });

--- a/test/validators/users/update.test.js
+++ b/test/validators/users/update.test.js
@@ -74,84 +74,84 @@ describe('users update validator', () => {
 
   });
 
-  describe('3ds_friend_code', () => {
+  describe('friend_code_3ds', () => {
 
     it('defaults to null', () => {
       const data = {};
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value['3ds_friend_code']).to.be.null;
+      expect(result.value.friend_code_3ds).to.be.null;
     });
 
     it('allows null', () => {
-      const data = { '3ds_friend_code': null };
+      const data = { friend_code_3ds: null };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value['3ds_friend_code']).to.be.null;
+      expect(result.value.friend_code_3ds).to.be.null;
     });
 
     it('converts the empty string to null', () => {
-      const data = { '3ds_friend_code': '' };
+      const data = { friend_code_3ds: '' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value['3ds_friend_code']).to.be.null;
+      expect(result.value.friend_code_3ds).to.be.null;
     });
 
     it('allows codes in the format of 1234-1234-1234', () => {
-      const data = { '3ds_friend_code': '1234-1234-1234' };
+      const data = { friend_code_3ds: '1234-1234-1234' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
       expect(result.error).to.not.exist;
     });
 
     it('disallows codes not in the format of 1234-1234-1234', () => {
-      const data = { '3ds_friend_code': '234-1234-1234' };
+      const data = { friend_code_3ds: '234-1234-1234' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.error.details[0].path).to.eql('3ds_friend_code');
+      expect(result.error.details[0].path).to.eql('friend_code_3ds');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"3ds_friend_code" must be a valid 3DS friend code/);
+      expect(result.error).to.match(/"friend_code_3ds" must be a valid 3DS friend code/);
     });
 
   });
 
-  describe('switch_friend_code', () => {
+  describe('friend_code_switch', () => {
 
     it('defaults to null', () => {
       const data = {};
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value.switch_friend_code).to.be.null;
+      expect(result.value.friend_code_switch).to.be.null;
     });
 
     it('allows null', () => {
-      const data = { switch_friend_code: null };
+      const data = { friend_code_switch: null };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value.switch_friend_code).to.be.null;
+      expect(result.value.friend_code_switch).to.be.null;
     });
 
     it('converts the empty string to null', () => {
-      const data = { switch_friend_code: '' };
+      const data = { friend_code_switch: '' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.value.switch_friend_code).to.be.null;
+      expect(result.value.friend_code_switch).to.be.null;
     });
 
     it('allows codes in the format of SW-1234-1234-1234', () => {
-      const data = { switch_friend_code: 'SW-1234-1234-1234' };
+      const data = { friend_code_switch: 'SW-1234-1234-1234' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
       expect(result.error).to.not.exist;
     });
 
     it('disallows codes not in the format of SW-1234-1234-1234', () => {
-      const data = { switch_friend_code: '1234-1234-1234' };
+      const data = { friend_code_switch: '1234-1234-1234' };
       const result = Joi.validate(data, UsersUpdateValidator);
 
-      expect(result.error.details[0].path).to.eql('switch_friend_code');
+      expect(result.error.details[0].path).to.eql('friend_code_switch');
       expect(result.error.details[0].type).to.eql('string.regex.base');
-      expect(result.error).to.match(/"switch_friend_code" must be a valid Switch friend code/);
+      expect(result.error).to.match(/"friend_code_switch" must be a valid Switch friend code/);
     });
 
   });


### PR DESCRIPTION
rename the columns (and params, vars, etc) so that we dont have to apply workarounds to the fact that `3ds_friend_code` starts with a number 