### PR TITLE
fix(evolutions): remove nulls from pokemon/evolutions array

### DIFF
--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -136,6 +136,15 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
       return family;
     }, { pokemon: [], evolutions: [] })
     .then((family) => {
+      // filter out nulls from evolutions that don't exist in the given game
+      // family or regionality
+      while (family.pokemon.length > 0 && !family.pokemon[0]) {
+        family.pokemon.shift();
+      }
+      while (family.evolutions.length > 0 && !family.evolutions[0]) {
+        family.evolutions.shift();
+      }
+
       if (family.pokemon.length === 0) {
         family.pokemon.push([this.get('summary')]);
       }

--- a/src/plugins/features/captures/controller.js
+++ b/src/plugins/features/captures/controller.js
@@ -52,10 +52,15 @@ exports.list = function (query, pokemon) {
         const bId = b.related('pokemon').get('dex_number_properties')[`${dex.related('game').related('game_family').get('id')}_id`];
 
         if (aId === bId) {
-          const aForm = a.related('pokemon').get('form');
-          const bForm = b.related('pokemon').get('form');
+          // The defaulting to the empty string is necessary since null doesn't
+          // sort the same way that the empty string does. Coverage is ignored
+          // for that line because it's difficult to make sure this sort
+          // function is called with right arguments.
+          const aForm = a.related('pokemon').get('form') || '';
+          /* istanbul ignore next */
+          const bForm = b.related('pokemon').get('form') || '';
 
-          return (aForm || '').localeCompare(bForm);
+          return aForm.localeCompare(bForm);
         }
 
         return aId - bId;


### PR DESCRIPTION
### evolutions bug

if a pre-evolution didnt exist in the provided game family/regionality, then it might end up producing an array with `null` as the first element (where the pre-evo is supposed to be). this fix strips all `null`s from the begin of the pokemon and evolutions array.

### sorting bug

because `null` sorts differently than `''`, we werent getting consistent results on the sorting since we werent defaulting all forms to `''`. this fixes that.