### PR TITLE
chore(slug): update slug to match frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![CircleCI](https://circleci.com/gh/pokedextracker/api.pokedextracker.com.svg?style=shield)](https://circleci.com/gh/pokedextracker/api.pokedextracker.com)
 [![Dependency Status](https://david-dm.org/pokedextracker/api.pokedextracker.com.svg)](https://david-dm.org/pokedextracker/api.pokedextracker.com)
 
-The API for [pokedextracker.com](http://pokedextracker.com). It's written in Node.js v5 using the following libraries/packages:
+The API for [pokedextracker.com](http://pokedextracker.com). It's written in
+Node.js using the following libraries/packages:
 
 * [Hapi](http://hapijs.com/) - API Framework
 * [Joi](https://github.com/hapijs/joi) - Data Validator
@@ -14,51 +15,66 @@ The API for [pokedextracker.com](http://pokedextracker.com). It's written in Nod
 
 ## Install
 
-This project is meant to be run with Node.js v6.14.2, so make sure you have it installed and active when running this application. This project also relies on the `yarn.lock` file to lock down dependency versions, so we recommend that you use [`yarn`](https://yarnpkg.com/en/) instead of `npm` to avoid "it works on my computer" bugs that are all too common with just a `package.json`. Assuming you have [`nodenv`](https://github.com/nodenv/nodenv) installed, you just need to install v6.14.2 and then install the dependencies:
+This project is meant to be run with the version of Node.js that is referenced
+in `.node-version`, so make sure you have it installed and active when running
+this application. This project also relies on the `yarn.lock` file to lock down
+dependency versions, so we recommend that you use
+[`yarn`](https://yarnpkg.com/en/) instead of `npm` to avoid "it works on my
+computer" bugs that are all too common with just a `package.json`. Assuming you
+have [`nodenv`](https://github.com/nodenv/nodenv) installed, you just need to
+install the appropriate version and then install the dependencies:
 
 ```bash
-$ nodenv install 6.14.2
-$ cd api.pokedextracker.com
-$ yarn
+nodenv install
+cd api.pokedextracker.com
+yarn
 ```
-
-The `.node-version` file should automatically switch the version for you whenever you `cd` into the project directory.
 
 ### Database
 
-This project uses PostgreSQL as its database, so you'll need to have the role and database setup. Assuming you already have it installed (either through [`brew`](http://brew.sh/) on OS X or `apt-get` on Ubuntu), you can just run the following:
+This project uses PostgreSQL as its database, so you'll need to have the role
+and database setup. Assuming you already have it installed (either through
+[`brew`](http://brew.sh/) on OS X or `apt-get` on Ubuntu), you can just run the
+following:
 
 ```
-$ psql postgres
-postgres=# CREATE ROLE "pokedex_tracker_admin" CREATEDB CREATEUSER LOGIN;
-$ createdb -O pokedex_tracker_admin pokedex_tracker
-$ yarn db:migrate
+createuser -d -r -l pokedex_tracker_admin
+createdb -O pokedex_tracker_admin pokedex_tracker
+yarn db:migrate
 ```
-
-### Secrets
-
-There are some secrets needed to run this repo locally, such as the Stripe API Key. Since no secrets are being checked in, you should copy `.env.example` to `.env` and populate it with all of the secrets listed there.
 
 ## Data
 
-This repo doesn't include a way to completely load up the DB with all of the actual Pokemon data. That's only been loaded into the staging and production databases. For testing purposes and to make sure everything is functioning as expected, having that data isn't entirely necessary. You should be relying on tests and factories instead of the database state.
+This repo doesn't include a way to completely load up the DB with all of the
+actual Pokemon data. That's only been loaded into the staging and production
+databases. For testing purposes and to make sure everything is functioning as
+expected, having that data isn't entirely necessary. You should be relying on
+tests and factories instead of the database state.
 
 ## Tests
 
-This project uses [Mocha](https://mochajs.org/) as the test runner, [Chai BDD](http://chaijs.com/api/bdd/) as our assertion library, and [Istanbul](https://github.com/gotwarlost/istanbul) to track code coverage. To run the tests locally, all you need to do is run:
+This project uses [Mocha](https://mochajs.org/) as the test runner, [Chai
+BDD](http://chaijs.com/api/bdd/) as our assertion library, and
+[Istanbul](https://github.com/gotwarlost/istanbul) to track code coverage. To
+run the tests locally, all you need to do is run:
 
 ```
-$ yarn test
+yarn test
 ```
 
-It will output the results of the test, and a coverage summary. To see a line-by-line breakdown of coverage to see what you missed, you should open `./coverage/lcov-report/index.html`.
+It will output the results of the test, and a coverage summary. To see a
+line-by-line breakdown of coverage to see what you missed, you should open
+`./coverage/lcov-report/index.html`.
 
 ## Docker
 
-Every merge into the `master` branch on GitHub triggers a new build for a Docker image. That image will overwrite the `latest` tag, and there will be an explicit tag with the first 7 characters of the commit hash. The server will be listening on port 8647 so if you run a container locally, make sure that traffic is forwarded to that port. For example:
+Every time we deploy this repo, we build a new Docker image and upload it to
+Docker Hub. We use an explicit tag with the first 7 characters of the commit
+hash. The server will be listening on port 8647 so if you run a container
+locally, make sure that traffic is forwarded to that port. For example:
 
  ```sh
-$ docker run --rm --publish 8647:8647 --name pokedextracker-api pokedextracker/api.pokedextracker.com:latest
+docker run --rm --publish 8647:8647 --name pokedextracker-api pokedextracker/api.pokedextracker.com:$(git rev-parse --short HEAD)
 ```
 
 ## Deployments
@@ -72,6 +88,5 @@ create a new release in the PokedexTracker Kubernetes cluster. Pass in the
 newly created Docker tag to deploy that version to the cluster.
 
 ```sh
-$ yarn deploy:staging 123abcd
-$ yarn deploy:production 123abcd
+yarn deploy
 ```

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jsonwebtoken": "^7.3.0",
     "knex": "^0.12.7",
     "pg": "^6.1.2",
-    "slug": "^0.9.1",
+    "slug": "^2.1.1",
     "stripe": "^5.1.1"
   },
   "devDependencies": {

--- a/test/plugins/features/dexes/controller.test.js
+++ b/test/plugins/features/dexes/controller.test.js
@@ -98,14 +98,6 @@ describe('dexes controller', () => {
       });
     });
 
-    it('rejects if trying to create a dex without a slug', () => {
-      return Controller.create(firstParams, { title: '为什么', shiny, game, regional }, firstUser)
-      .catch((err) => err)
-      .then((err) => {
-        expect(err).to.be.an.instanceof(Errors.EmptySlug);
-      });
-    });
-
     it('rejects if trying to create a dex for another user', () => {
       return Controller.create(secondParams, { title, shiny, game, regional }, firstUser)
       .catch((err) => err)
@@ -203,14 +195,6 @@ describe('dexes controller', () => {
           expect(capture.related('pokemon').get('game_family_id')).to.eql(oras.id);
           expect(capture.related('pokemon').get('dex_number_properties')[`${oras.id}_id`]).to.exist;
         });
-      });
-    });
-
-    it('rejects if trying to update a dex to one with an empty slug', () => {
-      return Controller.update(firstParams, { title: '为什么' }, firstUser)
-      .catch((err) => err)
-      .then((err) => {
-        expect(err).to.be.an.instanceof(Errors.EmptySlug);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,22 +260,6 @@ buffer-writer@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-1.0.1.tgz#22a936901e3029afcd7547eb4487ceb697a3bf08"
 
-"bufferjs@>= 2.0.0":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bufferjs/-/bufferjs-3.0.1.tgz#0692e829cb10a10550e647390b035eb06c38e8ef"
-
-"bufferstream@>= 0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/bufferstream/-/bufferstream-0.6.2.tgz#a5f27e10d3c760084d14b35126615007319e3731"
-  dependencies:
-    bufferjs ">= 2.0.0"
-  optionalDependencies:
-    buffertools ">= 1.0.3"
-
-"buffertools@>= 1.0.3":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/buffertools/-/buffertools-2.1.4.tgz#62d4e1584c0090a0c7d3587f25934a84b8b38de4"
-
 call@4.x.x:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/call/-/call-4.0.0.tgz#cd29381a98046a132db26e2628e70bd8321a1ddf"
@@ -2516,9 +2500,10 @@ slide@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
-slug@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/slug/-/slug-0.9.1.tgz#af08f608a7c11516b61778aa800dce84c518cfda"
+slug@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/slug/-/slug-2.1.1.tgz#08df390d4b4d51bafb41ac0067c0c2dd70734ef2"
+  integrity sha512-yNGhDdS0DR0JyxnPC84qIx/Vd01RHVY4guJeBqBNdBoOLNWnzw5zkWJvxVSmsuUb92bikdnQFnw3PfGY8uZ82g==
   dependencies:
     unicode ">= 0.3.1"
 
@@ -2782,10 +2767,9 @@ undefsafe@0.0.3:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
 
 "unicode@>= 0.3.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/unicode/-/unicode-0.6.1.tgz#ec69e3c4537e2b9650b826133bcb068f0445d0bc"
-  dependencies:
-    bufferstream ">= 0.6.2"
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/unicode/-/unicode-12.1.0.tgz#7ee53a7a0ca5539b353419432823d8da58bbbf33"
+  integrity sha512-Ty6+Ew21DiYTWLYtd05RF/X4c1ekOvOgANyHbBj0h3MaXpfaGr2Rdmc0hMFuGQLyPLb9cU4ArNxl0bTF5HSzXw==
 
 update-notifier@0.5.0:
   version "0.5.0"


### PR DESCRIPTION
### what

update `slug` to match the version used on the frontend. the older version (which used an older version of `unicode`) was also having issues downloading on osx catalina