### PR TITLE
fix(dexes): clear captures for dupes when going national

### DIFF
--- a/src/plugins/features/dexes/controller.js
+++ b/src/plugins/features/dexes/controller.js
@@ -96,6 +96,14 @@ exports.update = function (params, payload, auth) {
               this.groupBy('pokemon.id');
             });
           }
+          // If the dex is being changed to a national dex, delete all duplicate
+          // pokemon.
+          if (payload.regional === false) {
+            this.orWhereIn('pokemon_id', function () {
+              this.select('pokemon.id').from('pokemon');
+              this.where('national_order', '=', -1);
+            });
+          }
         });
       });
     }


### PR DESCRIPTION
### what

if a dex is going national, delete any captures for dupe pokemon (those with `national_order = -1`)