### PR TITLE
feat(users): add first_pokemon_db and second_pokemon_db

### DIFF
--- a/db/migrations/20201027141641_add_pokemon_db_link_options_to_users.js
+++ b/db/migrations/20201027141641_add_pokemon_db_link_options_to_users.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.string('first_pokemon_db', 20).defaultTo('Bulbapedia');
+    table.string('second_pokemon_db', 20).defaultTo('Serebii');
+  });
+};
+
+exports.down = function (Knex, Promise) {
+  return Knex.schema.table('users', (table) => {
+    table.dropColumn('first_pokemon_db');
+    table.dropColumn('second_pokemon_db');
+  });
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -17,6 +17,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         username: this.get('username'),
         friend_code_3ds: this.get('friend_code_3ds'),
         friend_code_switch: this.get('friend_code_switch'),
+        first_pokemon_db: this.get('first_pokemon_db'),
+        second_pokemon_db: this.get('second_pokemon_db'),
         date_created: this.get('date_created'),
         date_modified: this.get('date_modified')
       };
@@ -30,6 +32,8 @@ module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
         username: this.get('username'),
         friend_code_3ds: this.get('friend_code_3ds'),
         friend_code_switch: this.get('friend_code_switch'),
+        first_pokemon_db: this.get('first_pokemon_db'),
+        second_pokemon_db: this.get('second_pokemon_db'),
         dexes,
         donated: Boolean(this.get('stripe_id')),
         date_created: this.get('date_created'),

--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -48,6 +48,8 @@ exports.create = function (payload, request) {
         password: payload.password,
         friend_code_3ds: payload.friend_code_3ds,
         friend_code_switch: payload.friend_code_switch,
+        first_pokemon_db: payload.first_pokemon_db,
+        second_pokemon_db: payload.second_pokemon_db,
         referrer: payload.referrer,
         last_ip: ip
       }, { transacting })

--- a/src/validators/users/create.js
+++ b/src/validators/users/create.js
@@ -17,6 +17,8 @@ module.exports = Joi.object().keys({
         string: { regex: { base: 'must be a valid Switch friend code' } }
       }
     }),
+  first_pokemon_db: Joi.string().max(20).empty(['', null]),
+  second_pokemon_db: Joi.string().max(20).empty(['', null]),
   referrer: Joi.string().empty(['', null]),
   title: Joi.string().max(300).trim().required(),
   shiny: Joi.boolean().required(),

--- a/src/validators/users/update.js
+++ b/src/validators/users/update.js
@@ -15,5 +15,7 @@ module.exports = Joi.object().keys({
       language: {
         string: { regex: { base: 'must be a valid Switch friend code' } }
       }
-    })
+    }),
+  first_pokemon_db: Joi.string().max(20).empty(['', null]),
+  second_pokemon_db: Joi.string().max(20).empty(['', null])
 });

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -19,6 +19,8 @@ describe('user model', () => {
           'username',
           'friend_code_3ds',
           'friend_code_switch',
+          'first_pokemon_db',
+          'second_pokemon_db',
           'date_created',
           'date_modified'
         ]);
@@ -41,6 +43,8 @@ describe('user model', () => {
           'username',
           'friend_code_3ds',
           'friend_code_switch',
+          'first_pokemon_db',
+          'second_pokemon_db',
           'dexes',
           'donated',
           'date_created',

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -189,11 +189,13 @@ describe('users controller', () => {
 
     it('updates a user', () => {
       const friendCode = '4321-4321-4321';
+      const firstPokemonDB = 'Bulbapedia';
 
-      return Controller.update(firstUser.username, { friend_code_3ds: friendCode }, { id: firstUser.id })
+      return Controller.update(firstUser.username, { friend_code_3ds: friendCode }, { id: firstUser.id }, { first_pokemon_db: firstPokemonDB })
       .then(() => new User({ id: firstUser.id }).fetch())
       .then((user) => {
         expect(user.get('friend_code_3ds')).to.eql(friendCode);
+        expect(user.get('first_pokemon_db')).to.eql(firstPokemonDB);
       });
     });
 

--- a/test/validators/users/create.test.js
+++ b/test/validators/users/create.test.js
@@ -159,6 +159,88 @@ describe('users create validator', () => {
 
   });
 
+  describe('first_pokemon_db', () => {
+
+    it('is optional', () => {
+      const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('can be a string', () => {
+      const data = { username: 'testing', password: 'testtest', first_pokemon_db: 'Serebii', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+      expect(result.value.first_pokemon_db).to.eql(data.first_pokemon_db);
+    });
+
+    it('limits to 20 characters', () => {
+      const data = { username: 'testing', password: 'testtest', first_pokemon_db: 'a'.repeat(21), title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('first_pokemon_db');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+    it('converts null to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', first_pokemon_db: null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.first_pokemon_db).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', first_pokemon_db: '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.first_pokemon_db).to.be.undefined;
+    });
+
+  });
+
+  describe('second_pokemon_db', () => {
+
+    it('is optional', () => {
+      const data = { username: 'testing', password: 'testtest', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('can be a string', () => {
+      const data = { username: 'testing', password: 'testtest', second_pokemon_db: 'Serebii', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+      expect(result.value.second_pokemon_db).to.eql(data.second_pokemon_db);
+    });
+
+    it('limits to 20 characters', () => {
+      const data = { username: 'testing', password: 'testtest', second_pokemon_db: 'a'.repeat(21), title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('second_pokemon_db');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+    it('converts null to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', second_pokemon_db: null, title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.second_pokemon_db).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { username: 'testing', password: 'testtest', second_pokemon_db: '', title: 'Test', shiny: false, game: 'a', regional: true };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.second_pokemon_db).to.be.undefined;
+    });
+
+  });
+
   describe('referrer', () => {
 
     it('is optional', () => {

--- a/test/validators/users/update.test.js
+++ b/test/validators/users/update.test.js
@@ -115,4 +115,70 @@ describe('users update validator', () => {
 
   });
 
+  describe('first_pokemon_db', () => {
+
+    it('defaults to null', () => {
+      const data = {};
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.first_pokemon_db).to.be.undefined;
+    });
+
+    it('converts null to undefined', () => {
+      const data = { first_pokemon_db: null };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.first_pokemon_db).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { first_pokemon_db: '' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.first_pokemon_db).to.be.undefined;
+    });
+
+    it('limits to 20 characters', () => {
+      const data = { first_pokemon_db: 'a'.repeat(21) };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error.details[0].path).to.eql('first_pokemon_db');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('second_pokemon_db', () => {
+
+    it('defaults to undefined', () => {
+      const data = {};
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.second_pokemon_db).to.be.undefined;
+    });
+
+    it('converts null to undefined', () => {
+      const data = { second_pokemon_db: null };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.second_pokemon_db).to.be.undefined;
+    });
+
+    it('converts the empty string to undefined', () => {
+      const data = { second_pokemon_db: '' };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.value.second_pokemon_db).to.be.undefined;
+    });
+
+    it('limits to 20 characters', () => {
+      const data = { second_pokemon_db: 'a'.repeat(21) };
+      const result = Joi.validate(data, UsersUpdateValidator);
+
+      expect(result.error.details[0].path).to.eql('second_pokemon_db');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
 });


### PR DESCRIPTION
Fixes pokedextracker/pokedextracker.com#147

- Adds columns to Users table for preferences for links in the Info footers
- Includes these columns in create/retrieve/update controllers
- Unit tests for all of the above

Fully tested end-to-end