### PR TITLE
feat(pokemon): account for national orders < -1

### DIFF
--- a/src/plugins/features/captures/controller.js
+++ b/src/plugins/features/captures/controller.js
@@ -54,7 +54,7 @@ exports.list = function (query, pokemon) {
         return captures[pokemon[i].get('id')];
       }
 
-      if (!dex.get('regional') && pokemon[i].get('national_order') === -1) {
+      if (!dex.get('regional') && pokemon[i].get('national_order') < 0) {
         return null;
       }
 

--- a/src/plugins/features/dexes/controller.js
+++ b/src/plugins/features/dexes/controller.js
@@ -101,7 +101,7 @@ exports.update = function (params, payload, auth) {
           if (payload.regional === false) {
             this.orWhereIn('pokemon_id', function () {
               this.select('pokemon.id').from('pokemon');
-              this.where('national_order', '=', -1);
+              this.where('national_order', '<', 0);
             });
           }
         });


### PR DESCRIPTION
### what

with crown tundra, there are even more duplicates, so now there are some pokemon with national_order = -2. this PR accounts for those