### PR TITLE
chore(pokemon): remove dex_number_properties

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,18 +16,28 @@ fi
 
 KUBE_CONTEXT="$(echo "${KUBE_CONTEXTS}" | grep pokedextracker)"
 
+if ! docker buildx ls | grep -q multiarch; then
+  echo
+  echo -e "\033[1;32m==> Creating multiarch builder instance...\033[0m"
+  echo
+
+  docker buildx create --name multiarch --node multiarch
+fi
+
 echo
-echo -e "\033[1;32m==> Building ${TAG}...\033[0m"
+echo -e "\033[1;32m==> Building and pushing ${TAG} to ${REPO}...\033[0m"
 echo
 
-DOCKER_BUILDKIT=1 docker build -t ${REPO}:${TAG} .
-
-echo
-echo -e "\033[1;32m==> Pushing ${TAG} to ${REPO}...\033[0m"
-echo
-
-# this will fail if you're not logged in
-docker push ${REPO}:${TAG}
+# When building for other architectures, we can't keep the image locally, so we
+# need to push it in the same command that we build it. We build and push for
+# x86_64 and ARM64v8, just so we have both just in case. This will fail if
+# you're not logged in.
+DOCKER_BUILDKIT=1 docker buildx build \
+  --push \
+  --builder multiarch \
+  --platform linux/arm64,linux/amd64 \
+  --tag ${REPO}:${TAG} \
+  .
 
 echo
 echo -e "\033[1;32m==> Updating Helm repos\033[0m"

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -50,7 +50,7 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
       name: this.get('name'),
       game_family: this.related('game_family').serialize(),
       form: this.get('form')
-    }, this.get('dex_number_properties'), this.dex_specific_details(query.dex_type));
+    }, this.dex_specific_details(query.dex_type));
   },
   evolutions (query) {
     return new Evolution()
@@ -82,15 +82,6 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
     .get('models');
   },
   virtuals: {
-    dex_number_properties () {
-      return this.related('game_family_dex_numbers')
-        .reduce((dexNumbers, dexNumber) => {
-          const numbers = Object.assign({}, dexNumbers);
-          numbers[`${dexNumber.get('game_family_id')}_id`] = dexNumber.get('dex_number');
-
-          return numbers;
-        }, {});
-    },
     summary () {
       return {
         id: this.get('id'),
@@ -198,7 +189,7 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
         name: this.get('name'),
         game_family: this.related('game_family').serialize(),
         form: this.get('form')
-      }, this.get('dex_number_properties'), this.dex_specific_details(dexType), {
+      }, this.dex_specific_details(dexType), {
         locations,
         evolution_family: evolutionFamily
       });


### PR DESCRIPTION
### what

- removing the addition of the `dex_number_properties` since they aren't used on the frontend anymore
- update the deploy script to work with apple silicon