### PR TITLE
feat(slug): allow slug to be passed through

### DIFF
--- a/src/plugins/features/dexes/controller.js
+++ b/src/plugins/features/dexes/controller.js
@@ -28,7 +28,7 @@ exports.create = function (params, payload, auth) {
     }
 
     payload.user_id = auth.id;
-    payload.slug = Slug(payload.title, { lower: true });
+    payload.slug = payload.slug || Slug(payload.title, { lower: true });
 
     if (payload.slug === '') {
       throw new Errors.EmptySlug();
@@ -83,7 +83,7 @@ exports.update = function (params, payload, auth) {
   })
   .spread((dex, game, dexType) => {
     if (payload.title) {
-      payload.slug = Slug(payload.title, { lower: true });
+      payload.slug = payload.slug || Slug(payload.title, { lower: true });
 
       if (payload.slug === '') {
         throw new Errors.EmptySlug();

--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -65,7 +65,7 @@ exports.create = function (payload, request) {
         return new Dex().save({
           user_id: user.id,
           title: payload.title,
-          slug: Slug(payload.title, { lower: true }),
+          slug: payload.slug || Slug(payload.title, { lower: true }),
           shiny: payload.shiny,
           game_id: payload.game,
           dex_type_id: payload.dex_type

--- a/src/validators/dexes/create.js
+++ b/src/validators/dexes/create.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().max(300).trim().required(),
+  slug: Joi.string().max(300).trim(),
   shiny: Joi.boolean().required(),
   game: Joi.string().max(50).trim().required(),
   dex_type: Joi.number().integer().required()

--- a/src/validators/dexes/update.js
+++ b/src/validators/dexes/update.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 
 module.exports = Joi.object().keys({
   title: Joi.string().max(300).trim(),
+  slug: Joi.string().max(300).trim(),
   shiny: Joi.boolean(),
   game: Joi.string().max(50).trim(),
   dex_type: Joi.number().integer()

--- a/src/validators/users/create.js
+++ b/src/validators/users/create.js
@@ -19,6 +19,7 @@ module.exports = Joi.object().keys({
     }),
   referrer: Joi.string().empty(['', null]),
   title: Joi.string().max(300).trim().required(),
+  slug: Joi.string().max(300).trim(),
   shiny: Joi.boolean().required(),
   game: Joi.string().max(50).trim().required(),
   dex_type: Joi.number().integer().required()


### PR DESCRIPTION
### what

allow passing the slug from the frontend instead of relying on the backend to generate it. it's difficult to manage when both the frontend and the backend generate slugs since they could get out of sync, and it's not a great experience when you think the slug is gonna be one value because the frontend showed you that, but then the backend generates a different one. so instead, we're just gonna let the frontend handle all the slug logic, and it will just pass through what the slug should be.