### PR TITLE
fix(db): catch user canceled errors

### DIFF
--- a/pkg/errcodes/checks.go
+++ b/pkg/errcodes/checks.go
@@ -10,6 +10,7 @@ import (
 const (
 	PGDeadlockDetectedCode = "40P01"
 	PGUniqueViolationCode  = "23505"
+	PGUserCancel           = "57014"
 )
 
 func IsPGDeadlockDetected(err error) bool {
@@ -20,4 +21,9 @@ func IsPGDeadlockDetected(err error) bool {
 func IsPGUniqueViolation(err error) bool {
 	var pgerr pg.Error
 	return errors.As(err, &pgerr) && pgerr.Field('C') == PGUniqueViolationCode
+}
+
+func IsPGUserCancel(err error) bool {
+	var pgerr pg.Error
+	return errors.As(err, &pgerr) && pgerr.Field('C') == PGUserCancel
 }

--- a/pkg/errcodes/handler.go
+++ b/pkg/errcodes/handler.go
@@ -31,6 +31,12 @@ func (h *Handler) Handle(err error, c echo.Context) {
 		logger.FromEchoContext(c).Warn("context canceled")
 		return
 	}
+	if IsPGUserCancel(err) {
+		// If the context was cancelled during a SQL query, so the query ended early. This is also probably because the
+		// client canceled the request, so we don't need to error on it.
+		logger.FromEchoContext(c).Warn("user canceled statement")
+		return
+	}
 
 	httpCode, payload := h.generatePayload(c, err)
 


### PR DESCRIPTION
### what

in addition to the context canceled errors, it's possible for sql queries to be canceled, and that returns an error from postgres instead of go, so we need to handle that too