### PR TITLE
fix(db): catch all possible unique constraint errors

### DIFF
--- a/pkg/errcodes/errors.go
+++ b/pkg/errcodes/errors.go
@@ -159,11 +159,11 @@ func EmptySlug() error {
 	}
 }
 
-func ExistingUser() error {
+func ExistingUsername() error {
 	return &Error{
 		http.StatusUnprocessableEntity,
 		"username is already taken",
-		"existing_user",
+		"existing_username",
 	}
 }
 

--- a/pkg/users/handlers.go
+++ b/pkg/users/handlers.go
@@ -42,7 +42,7 @@ func (h *handler) create(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 	if existing != nil {
-		return errcodes.ExistingDex()
+		return errcodes.ExistingUsername()
 	}
 
 	// Fetch the provided game and dex type to make sure they exist, but also to compare their game family IDs.

--- a/pkg/users/service.go
+++ b/pkg/users/service.go
@@ -39,6 +39,9 @@ func (svc *Service) CreateUserAndDex(ctx context.Context, user *User, dex *dexes
 			Returning("*").
 			Insert()
 		if err != nil {
+			if errcodes.IsPGUniqueViolation(err) {
+				return errcodes.ExistingUsername()
+			}
 			return errors.WithStack(err)
 		}
 


### PR DESCRIPTION
### what

- i recently added a check for captures unique constraint violations (#140), but this adds in all the other ones that we had back in the node code base
- also return the existing username error instead of the existing dex error if a username is already taken