### PR TITLE
feat(locations): convert value into values instead of splitting by comma

### DIFF
--- a/cmd/migrations/20230630222236_add_values_to_locations.go
+++ b/cmd/migrations/20230630222236_add_values_to_locations.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/go-pg/pg/v10/orm"
+	"github.com/pkg/errors"
+	migrations "github.com/robinjoseph08/go-pg-migrations/v3"
+)
+
+func init() {
+	up := func(db orm.DB) error {
+		_, err := db.Exec(`ALTER TABLE locations ADD COLUMN values TEXT[]`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec("UPDATE locations SET values = regexp_split_to_array(locations.value, '(?!Let''s Go), (?!(Pikachu|Eevee))')")
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec("ALTER TABLE locations ALTER COLUMN values SET NOT NULL")
+		return errors.WithStack(err)
+	}
+
+	down := func(db orm.DB) error {
+		_, err := db.Exec(`ALTER TABLE locations DROP COLUMN values`)
+		return errors.WithStack(err)
+	}
+
+	opts := migrations.MigrationOptions{}
+
+	migrations.Register("20230630222236_add_values_to_locations", up, down, opts)
+}

--- a/pkg/pokemon/models.go
+++ b/pkg/pokemon/models.go
@@ -1,7 +1,6 @@
 package pokemon
 
 import (
-	"strings"
 	"time"
 
 	"github.com/pokedextracker/api.pokedextracker.com/pkg/games"
@@ -34,19 +33,18 @@ type Location struct {
 	Game      *games.Game `pg:"g,rel:has-one" json:"game"`
 	PokemonID int         `json:"-"`
 	Value     string      `json:"value"`
+	Values    []string    `pg:",array" json:"values"`
 }
 
 // MarshalJSON is just needed for parity testing. Once we're actually using this in production, we can remove it.
 func (l *Location) MarshalJSON() ([]byte, error) {
-	value := strings.Split(l.Value, ", ")
-
 	type Alias Location
 	return json.Marshal(&struct {
 		*Alias
 		Value []string `json:"value"`
 	}{
 		Alias: (*Alias)(l),
-		Value: value,
+		Value: l.Values,
 	})
 }
 


### PR DESCRIPTION
### what

add a new column `values` to `locations` and populate it using the logic that we used to use in node (splitting by a regex with negative lookahead). negative lookahead isn't supported by go, so we can't do that in the same way that we did before, but it also didn't make a ton of sense why we were splitting every time. so now we just store the info split and return it directly. this will fix the incorrectly splitting that is currently in production

![image](https://github.com/pokedextracker/api.pokedextracker.com/assets/2454505/32597f32-22a8-4c05-ace7-019d6c02a5df)
