### PR TITLE
fix(dexes): load dex type's base dex type

### DIFF
--- a/pkg/dexes/service.go
+++ b/pkg/dexes/service.go
@@ -59,6 +59,7 @@ func (svc *Service) RetrieveDex(ctx context.Context, opts RetrieveDexOptions) (*
 		ColumnExpr("(SELECT COUNT(*) FROM captures WHERE dex_id = d.id) AS caught").
 		ColumnExpr("(SELECT COUNT(*) FROM dex_types_pokemon WHERE dex_type_id = d.dex_type_id) AS total").
 		Relation("DexType").
+		Relation("DexType.BaseDexType").
 		Relation("Game").
 		Relation("Game.GameFamily")
 

--- a/pkg/dextypes/models.go
+++ b/pkg/dextypes/models.go
@@ -22,6 +22,7 @@ type DexType struct {
 	Order         int                        `json:"order"`
 	Tags          []string                   `pg:",array" json:"tags"`
 	BaseDexTypeID *int                       `json:"base_dex_type_id,omitempty"`
+	BaseDexType   *DexType                   `json:"base_dex_type,omitempty"`
 	Pokemon       []*pokemoncaptures.Pokemon `pg:"p,many2many:dex_types_pokemon" json:"-"`
 }
 

--- a/pkg/users/service.go
+++ b/pkg/users/service.go
@@ -69,6 +69,7 @@ func (svc *Service) RetrieveUser(ctx context.Context, opts RetrieveUserOptions) 
 				Order("d.date_created ASC"), nil
 		}).
 		Relation("Dexes.DexType").
+		Relation("Dexes.DexType.BaseDexType").
 		Relation("Dexes.Game").
 		Relation("Dexes.Game.GameFamily")
 


### PR DESCRIPTION
### what

load a dex's dex type's base dex type so that we can know the name of it in the dex indicator component on the frontend